### PR TITLE
Issue 9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Adds support to ${navigation_root_url} and ${portal_url} in Dexterity links.
+  (closes `#9`_).
+  [idgserpro]
 
 
 1.1 (2016-05-20)
@@ -158,3 +160,5 @@ Merged collections branch.
 
 Initial release
 
+
+.. _`#9`: https://github.com/collective/Products.Doormat/issues/9

--- a/Products/Doormat/browser/views.py
+++ b/Products/Doormat/browser/views.py
@@ -15,7 +15,11 @@ else:
 
 try:
     pkg_resources.get_distribution('plone.app.contenttypes')
-    from plone.app.contenttypes.utils import replace_link_variables_by_paths
+    try:
+        from plone.app.contenttypes.utils import replace_link_variables_by_paths
+    except ImportError:
+        # plone.app.contenttypes is not a Products.Doormart dependency.
+        pass
 except pkg_resources.DistributionNotFound:
     # We only use this import in an 'if' clause that asks if
     #     item.meta_type.startswith('Dexterity')

--- a/Products/Doormat/browser/views.py
+++ b/Products/Doormat/browser/views.py
@@ -14,6 +14,15 @@ else:
     from plone.app.collection.interfaces import ICollection
 
 try:
+    pkg_resources.get_distribution('plone.app.contenttypes')
+    from plone.app.contenttypes.utils import replace_link_variables_by_paths
+except pkg_resources.DistributionNotFound:
+    # We only use this import in an 'if' clause that asks if
+    #     item.meta_type.startswith('Dexterity')
+    # So no harm in using 'pass' here.
+    pass
+
+try:
     pkg_resources.get_distribution('plone.app.contenttypes>=1.0b2')
 except pkg_resources.VersionConflict:
     # older versions don't have the dx-based-collections
@@ -91,7 +100,10 @@ class DoormatView(BrowserView):
                     elif item.portal_type == "Link":
                         if item.meta_type.startswith('Dexterity'):
                             # A Dexterity-link
-                            url = item.remoteUrl
+                            url = replace_link_variables_by_paths(
+                                self.context,
+                                item.remoteUrl
+                            )
                         else:
                             # Link is an Archetypes link
                             url = item.getRemoteUrl

--- a/Products/Doormat/testing.py
+++ b/Products/Doormat/testing.py
@@ -24,6 +24,18 @@ class ProductsDoormatLayer(PloneSandboxLayer):
         )
         z2.installProduct(app, 'Products.Doormat')
 
+        import plone.app.contenttypes
+        xmlconfig.file(
+            'configure.zcml',
+            plone.app.contenttypes,
+            context=configurationContext
+        )
+
+        # XXX:
+        # plone.app.contenttypes needs plone.app.event, who needs this one.
+        # https://github.com/plone/plone.app.event/issues/81
+        z2.installProduct(app, 'Products.DateRecurringIndex')
+
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'Products.Doormat:default')
         portal.acl_users.userFolderAddUser('admin',
@@ -35,9 +47,13 @@ class ProductsDoormatLayer(PloneSandboxLayer):
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
     def tearDownPloneSite(self, portal):
+
         # not implemented yet
         #applyProfile(portal, 'Products.Doormat:uninstall')
-        pass
+
+        # plone.app.contenttypes needs plone.app.event, who needs this one.
+        # https://github.com/plone/plone.app.event/issues/81
+        z2.uninstallProduct(portal, 'Products.DateRecurringIndex')
 
 
 PRODUCTS_DOORMAT_FIXTURE = ProductsDoormatLayer()

--- a/Products/Doormat/tests/test_views.py
+++ b/Products/Doormat/tests/test_views.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
+from plone.app.testing import applyProfile
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from plone.i18n.normalizer.interfaces import IURLNormalizer
+from Products.CMFCore.utils import getToolByName
 from Products.Doormat.testing import PRODUCTS_DOORMAT_INTEGRATION_TESTING
-from plone.app.testing import TEST_USER_ID, setRoles
+from zope.component import queryUtility
 
 import unittest2 as unittest
 
@@ -45,7 +50,7 @@ class DoormatViewTest(unittest.TestCase):
     def test_collection(self):
         self.assertEqual(len([col.Title for col in self.collection.queryCatalog()]),2)
         self.assertItemsEqual([col.Title for col in self.collection.queryCatalog()],['News 1','News 2'])
-        
+
     def test_doormat_view(self):
         view = self.portal.doormat.restrictedTraverse('@@doormat-view')
         view()
@@ -68,6 +73,68 @@ class DoormatViewTest(unittest.TestCase):
         door_collection.setLimit(1)
         results = view.getCollection(door_collection)
         self.assertItemsEqual([item.Title for item in results],['News 1',])
+
+    def test_replace_link_variables_by_paths_for_dx_links(self):
+        # This is needed because this test is only for Dexterity: if I don't
+        # make the Link type from DX available, it will use Archetypes making
+        # this test useless.
+        applyProfile(self.portal, 'plone.app.contenttypes:default')
+
+        normalizer = queryUtility(IURLNormalizer)
+
+        section = self.catalog(dict(portal_type="DoormatSection"))
+        section_obj = section[0].getObject()
+
+        # ${portal_url}
+        link_title_portal_url = u'Link Portal Url'
+        link_id_portal_url = normalizer.normalize(link_title_portal_url)
+        link_url_portal_url = u'/plone/{0}'.format(link_id_portal_url)
+        remote_url_portal_url = u'${{portal_url}}/{0}'.format(link_id_portal_url)
+        section_obj.invokeFactory(
+            u'Link',
+            link_id_portal_url,
+            title=link_title_portal_url,
+            remoteUrl=remote_url_portal_url,
+        )
+        #
+
+        # ${navigation_root_url}
+        link_title_navigation_root_url = u'Link Navigation Root Url'
+        link_id_navigation_root_url = normalizer.normalize(
+            link_title_navigation_root_url
+        )
+        link_url_navigation_root_url = u'/plone/{0}'.format(
+            link_id_navigation_root_url
+        )
+        remote_url_navigation_root_url = u'${{navigation_root_url}}/{0}'.format(
+            link_id_navigation_root_url
+        )
+        section_obj.invokeFactory(
+            u'Link',
+            link_id_navigation_root_url,
+            title=link_title_navigation_root_url,
+            remoteUrl=remote_url_navigation_root_url,
+        )
+        #
+
+        portal_url_ok = False
+        navigation_root_url_ok = False
+        view = self.portal.doormat.restrictedTraverse('@@doormat-view')
+        data = view.getDoormatData()
+        for column in data:
+            for section in column['column_sections']:
+                for link in section['section_links']:
+                    if link['link_title'] == link_title_portal_url:
+                        portal_url_ok = (
+                            link['link_url'] == link_url_portal_url
+                        )
+                    if link['link_title'] == link_title_navigation_root_url:
+                        navigation_root_url_ok = (
+                            link['link_url'] == link_url_navigation_root_url
+                        )
+
+        self.assertTrue(portal_url_ok)
+        self.assertTrue(navigation_root_url_ok)
 
 
 def test_suite():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.2.dev0'
+version = '1.2.dev1'
 
 setup(name='Products.Doormat',
       version=version,
@@ -42,7 +42,9 @@ setup(name='Products.Doormat',
       extras_require={
           'test': [
               'plone.app.testing',
-              'plone.app.contenttypes',
+              # I'm importing plone.app.contenttypes.utils, it doesn't exist
+              # in earlier versions.
+              'plone.app.contenttypes>=1.1b1',
               'unittest2',
           ],
       },

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.2.dev1'
+version = '1.2.dev2'
 
 setup(name='Products.Doormat',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name='Products.Doormat',
       extras_require={
           'test': [
               'plone.app.testing',
+              'plone.app.contenttypes',
               'unittest2',
           ],
       },


### PR DESCRIPTION
Fix https://github.com/collective/Products.Doormat/issues/9

Now ${navigation_root_url} and ${portal_url} in url is replaced in Doormat when using Dexterity.
